### PR TITLE
add platform strings for iPhone 7 & 7 Plus

### DIFF
--- a/UIDeviceHardware.m
+++ b/UIDeviceHardware.m
@@ -40,6 +40,10 @@
     if ([platform isEqualToString:@"iPhone8,1"])    return @"iPhone 6s";
     if ([platform isEqualToString:@"iPhone8,2"])    return @"iPhone 6s Plus";
     if ([platform isEqualToString:@"iPhone8,4"])    return @"iPhone SE";
+    if ([platform isEqualToString:@"iPhone9,1"])    return @"iPhone 7";
+    if ([platform isEqualToString:@"iPhone9,2"])    return @"iPhone 7 Plus";
+    if ([platform isEqualToString:@"iPhone9,3"])    return @"iPhone 7";
+    if ([platform isEqualToString:@"iPhone9,4"])    return @"iPhone 7 Plus";
 
     if ([platform isEqualToString:@"iPod1,1"])      return @"iPod Touch 1G";
     if ([platform isEqualToString:@"iPod2,1"])      return @"iPod Touch 2G";


### PR DESCRIPTION
I'm using this amazing source in my app and needed iPhone 7 & 7 Plus support. I've used the reference same as this repo uses.
http://theiphonewiki.com/wiki/Models

Please verify this and bring it on to the master so that it's useful for others also. Maybe publish a newer version pod?

Thanks.
