### PR TITLE
Add iPhone 11, 11 Pro, 11 Pro Max

### DIFF
--- a/UIDeviceHardware.m
+++ b/UIDeviceHardware.m
@@ -54,6 +54,9 @@
     if ([platform isEqualToString:@"iPhone11,4"])   return @"iPhone XS Max";
     if ([platform isEqualToString:@"iPhone11,6"])   return @"iPhone XS Max";
     if ([platform isEqualToString:@"iPhone11,8"])   return @"iPhone XR";
+    if ([platform isEqualToString:@"iPhone12,1"])   return @"iPhone 11";
+    if ([platform isEqualToString:@"iPhone12,3"])   return @"iPhone 11 Pro";
+    if ([platform isEqualToString:@"iPhone12,5"])   return @"iPhone 11 Pro Max";
 
     if ([platform isEqualToString:@"iPod1,1"])      return @"iPod Touch 1G";
     if ([platform isEqualToString:@"iPod2,1"])      return @"iPod Touch 2G";


### PR DESCRIPTION
I added following new iPhone devices that released in September 2019.

- iPhone 11
- iPhone 11 Pro
- iPhone 11 Pro Max